### PR TITLE
Change build process to use pep517 and twine

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -55,7 +55,8 @@ jobs:
             conda init
             conda env update --name build --file tests/environment.yml
             conda activate build
-            python setup.py bdist_wheel
+            pip install -U pip pep517 twine
+            python -m pep517.build .
             pip install dist/pyfoomb*.whl
             python -c "import pyfoomb; print(f'Can successfully import {pyfoomb.__name__} {pyfoomb.__version__}')"
             
@@ -66,7 +67,8 @@ jobs:
             conda init
             conda env update --name build --file tests/environment.yml
             conda activate build
-            python setup.py bdist_wheel
+            pip install -U pip pep517 twine
+            python -m pep517.build .
             cd dist
             pip install pyfoomb*.whl
             python -c "import pyfoomb; print(f'Can successfully import {pyfoomb.__name__} {pyfoomb.__version__}')"

--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,23 @@ healthchecksdb
 /pyfoomb.egg-info
 /.vscode/.ropeproject
 .vscode/launch.json
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+# inspired by https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
+
+# Tests
+recursive-include tests *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+# inspired by https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 110

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ __version__ = get_version()
 setuptools.setup(name = __packagename__,
         packages = setuptools.find_packages(exclude=['examples', '*test*']),
         version=__version__,
+        zip_safe=False,
         description='Package for handling systems of ordinary differential equations (ODEs) with discontinuities. Relies on assimulo package for ODE integration and pygmo package for optimization.',
         author='Johannes Hemmerich',
         author_email='hemmerich@outlook.com',


### PR DESCRIPTION
This PR changes the build process to use pep517 and twine to prevent possible upcoming problems with `easy_install`.  The implementation is inspired by https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/.